### PR TITLE
add nosql-common + MongoDB driver to featurepack

### DIFF
--- a/mongodb/build/assembly.xml
+++ b/mongodb/build/assembly.xml
@@ -12,6 +12,8 @@
 			<includes>
 				<include>docs/**/standalone-mongodb.xml</include>
 				<include>modules/**/mongodb/main/*.*</include>
+				<include>modules/**/nosql/common/main/*.*</include>
+                                <include>modules/**/mongodb/driver/main/*.*</include>
 			</includes>
 		</fileSet>
 	</fileSets>

--- a/mongodb/feature-pack/pom.xml
+++ b/mongodb/feature-pack/pom.xml
@@ -84,6 +84,17 @@
 	    <version>${version.wildfly-nosql-common}</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongo-java-driver</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
     </dependencies>
 
 

--- a/mongodb/feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/mongodb/feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -17,6 +17,18 @@
                     <properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
             </security-realm>
+
+           <security-realm name="mongoRealm">  
+               <authentication>  
+                   <login-module code="ConfiguredIdentity" flag="required">  
+                       <module-option name="userName" value="devuser"/>  
+                       <module-option name="principal" value="devuser"/>  
+                       <module-option name="password" value="changethis"/>  
+                   </login-module>  
+               </authentication>  
+           </security-realm>  
+
+
             <security-realm name="ApplicationRealm">
                 <server-identities>
                     <ssl>

--- a/mongodb/feature-pack/src/main/resources/configuration/standalone/template.xml
+++ b/mongodb/feature-pack/src/main/resources/configuration/standalone/template.xml
@@ -7,8 +7,8 @@
     </extensions>
 
     <management>
-        <security-realms>
-            <security-realm name="ManagementRealm">
+        <security-domains>
+            <security-domain name="ManagementRealm">
                 <authentication>
                     <local default-user="$local" skip-group-loading="true"/>
                     <properties path="mgmt-users.properties" relative-to="jboss.server.config.dir"/>
@@ -16,9 +16,9 @@
                 <authorization map-groups-to-roles="false">
                     <properties path="mgmt-groups.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
-            </security-realm>
+            </security-domain>
 
-           <security-realm name="mongoRealm">  
+           <security-domain name="mongoRealm">  
                <authentication>  
                    <login-module code="ConfiguredIdentity" flag="required">  
                        <module-option name="userName" value="devuser"/>  
@@ -26,10 +26,10 @@
                        <module-option name="password" value="changethis"/>  
                    </login-module>  
                </authentication>  
-           </security-realm>  
+           </security-domain>  
 
 
-            <security-realm name="ApplicationRealm">
+            <security-domain name="ApplicationRealm">
                 <server-identities>
                     <ssl>
                         <keystore path="application.keystore" relative-to="jboss.server.config.dir" keystore-password="password" alias="server" key-password="password" generate-self-signed-certificate-host="localhost"/>
@@ -42,8 +42,8 @@
                 <authorization>
                     <properties path="application-roles.properties" relative-to="jboss.server.config.dir"/>
                 </authorization>
-            </security-realm>
-        </security-realms>
+            </security-domain>
+        </security-domains>  <!-- use security-domain for WildFly 10.1.0 and security-realms for WildFly master (11) --> 
         <audit-log>
             <formatters>
                 <json-formatter name="json-formatter"/>


### PR DESCRIPTION
wildfly-nosql/mongodb/build/target/wildfly-mongodb-build-1.0.0.Alpha1-SNAPSHOT-bin.zip now contains the MongoDB integration module, common module + MongoDB driver.